### PR TITLE
boot-luks-lvm.sh fixes

### DIFF
--- a/scripts/boot-luks-lvm.sh
+++ b/scripts/boot-luks-lvm.sh
@@ -11,6 +11,7 @@ fi
 pkill cryptsetup
 sleep 2
 /sbin/cryptsetup luksOpen $1 root
-vgscan
-vgchange -a y
+sleep 2
+/bin/lvm vgscan
+/bin/lvm vgchange -a y
 /sbin/ttyecho -n /dev/console $2


### PR DESCRIPTION
use /bin/lvm vgscan/vgchange as they may not be included in the
initramfs, and sleep a bit to avoid a race condition (not present in boot-lvm.sh). 
